### PR TITLE
🐛: 색상 선택 에러 수정

### DIFF
--- a/MeDrop/MeDrop/Sources/Create/View/EnterDesignView.swift
+++ b/MeDrop/MeDrop/Sources/Create/View/EnterDesignView.swift
@@ -91,9 +91,6 @@ struct EnterDesignView: View {
                     Text("지금 돌아간다면 정보는 저장되지 않습니다. ")
                 }
             }
-            .onAppear {
-                selectedDesign = editingCard.designType.first?.wholeNumberValue ?? 0
-            }
             .navigationTitle("명함 디자인을 설정하세요")
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {

--- a/MeDrop/MeDrop/Sources/MyCards/View/CustomCarouselView.swift
+++ b/MeDrop/MeDrop/Sources/MyCards/View/CustomCarouselView.swift
@@ -32,7 +32,9 @@ struct CustomCarouselView: View {
                         isDetail.toggle()
                     }
                     .navigationDestination(isPresented: $isDetail) {
-                            CardDetailMyView(card: $cards[Int(index)], cards: $cards)
+                        if Int(draggingItem) < cards.count {
+                            CardDetailMyView(card: $cards[Int(draggingItem)], cards: $cards)
+                        }
                     }
                     .scaleEffect(0.9 - abs(distance(index)) * 0.2)
                     .opacity(Double(index) == draggingItem ? 1.0 : 0.5)


### PR DESCRIPTION
## 개요
색상 선택 에러 없애기 위해 
변수 할당하는 것 지웠습니다. 
명함 디자인 생성 / 수정에서 둘다 초기값 검정색 + 검정 다이아몬드 입니다.
## 작업사항

Closes #이슈번호